### PR TITLE
投稿機能拡張

### DIFF
--- a/app/Http/Controllers/ReviewController.php
+++ b/app/Http/Controllers/ReviewController.php
@@ -49,6 +49,12 @@ class ReviewController extends Controller
     return view('reviews.store');
   }
 
+  public function creation($id)
+  {
+    $shop = Shop::find($id);
+    return view('reviews.creation')->with('shop',$shop);
+  }
+
   public function edit($id)
   {
     $review = Review::find($id);

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -16,6 +16,7 @@ Route::group(['middleware' => ['web']], function () {
     Route::resource('/shops', 'ShopController');
 
     Route::resource('/review', 'ReviewController');
+    Route::get('/review/creation/{id}','ReviewController@creation');
 
     Route::get('/review/{id}/delete', 'ReviewController@destroy');
 

--- a/public/assets/javascripts/searchmap.js
+++ b/public/assets/javascripts/searchmap.js
@@ -64,12 +64,12 @@ function shuffle(array) {
             position: result,
             animation: google.maps.Animation.DROP,
             opacity:1,
-
             label: {
                 text: shoprand[counter]['genre'].slice(0,1),                           //ラベル文字
                 color: 'black',                    //文字の色
                 fontSize: '20px'                     //文字のサイズ
             }
+            
         });
         marker1.setMap(map);
         marker.push(marker1);
@@ -93,7 +93,7 @@ function shuffle(array) {
                 + shoprand[counter]["shop_name"] + '</a>('+shoprand[counter]['genre']+')<br>'
                 + '<p></p>'
                 + '<a href ='+ shopshow +'>Read Review!</a>'+"  /   "
-                + '<a href =/review/create>'+"Let's Review!"+'</a>'
+                + '<a href =/review/creation/' + shoprand[counter]['id'] +'>'+"Let's Review!"+'</a>'
                 + '</div>',
               });
             infoWindow.push(infoWindow1);

--- a/public/assets/javascripts/searchmap.js
+++ b/public/assets/javascripts/searchmap.js
@@ -235,7 +235,7 @@ function shuffle(array) {
                   + genrepin[counter2]["shop_name"] + '</a>('+genrepin[counter2]['genre']+')<br>'
                   + '<p></p>'
                   + '<a href ='+ shopshow +'>Read Review!</a>'+"  /   "
-                  + '<a href =/review/create>'+"Let's Review!"+'</a>'
+                  + '<a href =/review/creation/' + genrepin[counter2]['id'] +'>'+"Let's Review!"+'</a>'
                   + '</div>'
                 });
               infoWindow2.push(infoWindow1);

--- a/resources/views/reviews/creation.blade.php
+++ b/resources/views/reviews/creation.blade.php
@@ -1,0 +1,44 @@
+@extends('layout')
+
+@section('content')
+  <main>
+    {{ Form::open(['url' => '/review', 'method' => 'post', 'files' => true]) }}
+      <div id="form-main">
+        <div id="form-div">
+          <h2>{{$shop->shop_name}}に投稿する</h2>
+          <div class="form" id="form1" action="">
+            <p class="shop_name">
+                <select required class="feedback-input-post" name="shop_id">
+                    <option value="{{$shop->id}}" hidden>{{$shop->shop_name}}</option>
+                </select>
+
+              </div>
+            </p>
+            <p class="rate_select">
+              <select required class="feedback-input-post" name="rate">
+                <option value="" hidden>Rate Select</option>
+                <option value="1">1</option>
+                <option value="2">2</option>
+                <option value="3">3</option>
+                <option value="4">4</option>
+                <option value="5">5</option>
+              </select>
+            </p>
+            <p class="text">
+              <textarea name="text" class="validate[required,length[6,300]] feedback-input" id="comment" placeholder="Comment"></textarea>
+            </p>
+
+            <p class="field">
+            {{ Form::file('images') }}
+            </p>
+
+            <div class="submit">
+              <input type="submit" value="Post" id="button-blue"/>
+              <div class="ease"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  {{ Form::close() }}
+@endsection


### PR DESCRIPTION
レビューコントローラーにcreationアクションを追加し、それに伴いルーティング、ビューファイルを追加しました。
マップのふきだしから投稿ページに飛ぶと、店が選択された状態でレビューを行うことができます。